### PR TITLE
Update to SI prefixes, correction of amount of substance fraction, minor text changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 Icon?
+
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,1 @@
 Icon?
-
-.idea/

--- a/sysml.library/Domain Libraries/Quantities and Units/ISQChemistryMolecular.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/ISQChemistryMolecular.sysml
@@ -409,14 +409,14 @@ standard library package ISQChemistryMolecular {
          */
     }
 
-    /* ISO-80000-9 item 9-13 amount-of-substance fraction mole fraction */
-    attribute def AmountOfSubstanceFractionMoleFractionValue :> DimensionOneValue {
+    /* ISO-80000-9 item 9-13 amount-of-substance fraction, mole fraction */
+    attribute def AmountOfSubstanceFractionValue :> DimensionOneValue {
         doc
         /*
-         * source: item 9-13 amount-of-substance fraction mole fraction
+         * source: item 9-13 amount-of-substance fraction, mole fraction
          * symbol(s): `x_X`, `y_X`
          * application domain: generic
-         * name: AmountOfSubstanceFractionMoleFraction (specializes DimensionOneQuantity)
+         * name: AmountOfSubstanceFraction (specializes DimensionOneQuantity)
          * quantity dimension: 1
          * measurement unit(s): 1
          * tensor order: 0

--- a/sysml.library/Domain Libraries/Quantities and Units/ISQLight.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/ISQLight.sysml
@@ -408,11 +408,11 @@ standard library package ISQLight {
         attribute :>> quantityDimension { :>> quantityPowerFactors = (lengthPF, massPF, durationPF); }
     }
 
-    /* ISO-80000-7 item 7-8.1 radiant exitance , radiant emittance */
+    /* ISO-80000-7 item 7-8.1 radiant exitance, radiant emittance */
     attribute def RadiantExitanceValue :> ScalarQuantityValue {
         doc
         /*
-         * source: item 7-8.1 radiant exitance , radiant emittance
+         * source: item 7-8.1 radiant exitance, radiant emittance
          * symbol(s): `M_e`, `(M)`
          * application domain: generic
          * name: RadiantExitance

--- a/sysml.library/Domain Libraries/Quantities and Units/ISQThermodynamics.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/ISQThermodynamics.sysml
@@ -703,7 +703,7 @@ standard library package ISQThermodynamics {
          * measurement unit(s): J/(kg*K), m^2*s^-2*K^-1
          * tensor order: 0
          * definition: quotient of entropy and mass: `s = S/m` where `S` is entropy (item 5-18) and `m` is mass (ISO 80000-4)
-         * remarks: For the corresponding quantity related to amount of substance, see ISO 80000-9.
+         * remarks: For the corresponding quantities related to amount of substance, see ISO 80000-9.
          */
         attribute :>> num: Real;
         attribute :>> mRef: SpecificEntropyUnit[1];

--- a/sysml.library/Domain Libraries/Quantities and Units/SIPrefixes.sysml
+++ b/sysml.library/Domain Libraries/Quantities and Units/SIPrefixes.sysml
@@ -11,6 +11,8 @@ standard library package SIPrefixes {
 	 * 
 	 * See also https://en.wikipedia.org/wiki/Unit_prefix
 	 */
+	attribute quecto: UnitPrefix { :>> longName = "quecto"; :>> symbol = "q"; :>> conversionFactor = 1E-30; }
+	attribute ronto: UnitPrefix { :>> longName = "ronto"; :>> symbol = "r"; :>> conversionFactor = 1E-27; }
 	attribute yocto: UnitPrefix { :>> longName = "yocto"; :>> symbol = "y"; :>> conversionFactor = 1E-24; }
 	attribute zepto: UnitPrefix { :>> longName = "zepto"; :>> symbol = "z"; :>> conversionFactor = 1E-21; }
 	attribute atto: UnitPrefix { :>> longName = "atto"; :>> symbol = "a"; :>> conversionFactor = 1E-18; }
@@ -31,7 +33,9 @@ standard library package SIPrefixes {
 	attribute exa: UnitPrefix { :>> longName = "exa"; :>> symbol = "E"; :>> conversionFactor = 1E18; }
 	attribute zetta: UnitPrefix { :>> longName = "zetta"; :>> symbol = "Z"; :>> conversionFactor = 1E21; }
 	attribute yotta: UnitPrefix { :>> longName = "yotta"; :>> symbol = "Y"; :>> conversionFactor = 1E24; }
-	
+	attribute ronna: UnitPrefix { :>> longName = "ronna"; :>> symbol = "R"; :>> conversionFactor = 1E27; }
+	attribute quetta: UnitPrefix { :>> longName = "quetta"; :>> symbol = "Q"; :>> conversionFactor = 1E30; }
+
 	/*
 	 * ISO/IEC 80000-1 prefixes for binary multiples, i.e. multiples of 1024 (= 2^10)
 	 * 


### PR DESCRIPTION
This PR contains the following changes for consideration:

- addition of the newly approved SI prefixes (sysml.library/Domain Libraries/Quantities and Units/SIPrefixes.sysml)
- revision of the representation of 'amount of substance fraction' (sysml.library/Domain Libraries/Quantities and Units/ISQChemistryMolecular.sysml)
- removal of extra space in 'radiant exitance' (sysml.library/Domain Libraries/Quantities and Units/ISQLight.sysml)
- revision (for consistency) to remarks (sysml.library/Domain Libraries/Quantities and Units/ISQThermodynamics.sysml)