### PR TITLE
Update install.bat

### DIFF
--- a/install/jupyter/install.bat
+++ b/install/jupyter/install.bat
@@ -20,7 +20,7 @@
 
 @echo off
 
-set /A SYSML_VERSION="0.36.0"
+set SYSML_VERSION="0.36.0"
 
 echo --- Step 1: Testing Conda installation ---
 where conda


### PR DESCRIPTION
According to the windows command shell, the flag "/A" is for numerical expressions: "The /A switch specifies that the string to the right of the equal sign is a numerical expression that is evaluated."

The issue here is, that "0.36.0" is not a valid numerical expression. This can be tested with the following command: set /A "x=0.36.0" & echo x=%x%. The expected output would be x=0.36.0. But due to the flag /A, set returns:

Missing operator.
x=0

Removed the flag and change the line in install.bat to: set SYSML_VERSION="0.36.0" 

Tested with: Microsoft Windows [Version 10.0.19045.3570]