### PR TITLE
Fix typo in AnalysisIndividualExample (#121)

### DIFF
--- a/sysml/src/examples/Individuals Examples/AnalysisIndividualExample.sysml
+++ b/sysml/src/examples/Individuals Examples/AnalysisIndividualExample.sysml
@@ -83,7 +83,7 @@ package AnalysisIndividualExample {
 					attribute :>> fuelEfficiency = 0.4;
 				}
 			}
-			individual action :>> fuelConsumption : FuelEconomyAnalysis_1 {
+			individual action :>> fuelConsumption : FuelConsumption_1 {
 				snapshot :>> done :> fuelConsumption {
 					out :>> fuelEconomy = 35[mph];
 				}


### PR DESCRIPTION
## Fix typo in AnalysisIndividualExample

Fixes #121.

In `AnalysisIndividualExample.sysml`, the redefinition of `fuelConsumption` (line 86) was typed with the **analysis** individual `FuelEconomyAnalysis_1` instead of the **action** individual `FuelConsumption_1`.

The enclosing `fuelConsumption` action is typed by `FuelConsumption` (line 59), and the corresponding individual definition is `individual action def FuelConsumption_1 :> FuelConsumption;` (line 77). The individual redefinition should therefore reference `FuelConsumption_1`, not `FuelEconomyAnalysis_1`.

### Change
```diff
- individual action :>> fuelConsumption : FuelEconomyAnalysis_1 {
+ individual action :>> fuelConsumption : FuelConsumption_1 {
```

One-line fix as described in the issue.
